### PR TITLE
add specific exception for content policy

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -362,7 +362,11 @@ class APIRequestor:
                 error_data.get("message"), rbody, rcode, resp, rheaders
             )
         elif rcode in [400, 404, 415]:
-            return error.InvalidRequestError(
+            error_type = error.InvalidRequestError
+            if error_data.get("code") == "content_filter":
+                error_type = error.ContentPolicyError
+
+            return error_type(
                 error_data.get("message"),
                 error_data.get("param"),
                 error_data.get("code"),

--- a/openai/error.py
+++ b/openai/error.py
@@ -1,3 +1,4 @@
+import json
 import openai
 
 
@@ -167,3 +168,33 @@ class SignatureVerificationError(OpenAIError):
             self.sig_header,
             self.http_body,
         )
+
+
+class ContentPolicyError(InvalidRequestError):
+
+    def __init__(
+        self,
+        message,
+        param,
+        code=None,
+        http_body=None,
+        http_status=None,
+        json_body=None,
+        headers=None,
+    ):
+        super().__init__(
+            message,
+            param,
+            code=code,
+            http_body=http_body,
+            http_status=http_status,
+            json_body=json_body,
+            headers=headers
+        )
+        self.content_filter_result = json_body["error"]["innererror"]["content_filter_result"]
+
+
+    def __str__(self):
+        if self.json_body["error"].get("innererror"):
+            return f"{self._message}\nInner error: {json.dumps(self.json_body['error'].get('innererror'), indent=4)}"
+        return self._message

--- a/openai/error.py
+++ b/openai/error.py
@@ -191,10 +191,11 @@ class ContentPolicyError(InvalidRequestError):
             json_body=json_body,
             headers=headers
         )
-        self.content_filter_result = json_body["error"]["innererror"]["content_filter_result"]
+        self.innererror = self.json_body["error"].get("innererror", {})
+        self.content_filter_result = self.innererror.get("content_filter_result")
 
 
     def __str__(self):
-        if self.json_body["error"].get("innererror"):
-            return f"{self._message}\nInner error: {json.dumps(self.json_body['error'].get('innererror'), indent=4)}"
+        if self.innererror:
+            return f"{self._message}\nInner error: {json.dumps(self.innererror, indent=4)}"
         return self._message


### PR DESCRIPTION
### Catching exception experience:

```python
import openai

try:
    openai.Completion.create(
        prompt="How do I rob a bank?",
        deployment_id="text-davinci-003",
    )
except openai.error.InvalidRequestError as e:
    if e.error.code == "content_filter" and e.error.innererror:
        content_filter_result = e.error.innererror.content_filter_result

        for category, details in content_filter_result.items():
            print(f"{category}:\n filtered={details['filtered']}\n severity={details['severity']}")
```

vs.

```python
try:
    openai.Completion.create(
        prompt="How do I rob a bank?",
        deployment_id="text-davinci-003",
    )
except openai.error.ContentPolicyError as e:
    for category, details in e.content_filter_result.items():
        print(f"{category}:\n filtered={details['filtered']}\n severity={details['severity']}")
```

### Un-caught exception experience:

```cmd
openai.error.ContentPolicyError: The response was filtered due to the prompt triggering Azure OpenAI’s content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: https://go.microsoft.com/fwlink/?linkid=2198766
```
vs.

```cmd
openai.error.ContentPolicyError: The response was filtered due to the prompt triggering Azure OpenAI’s content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: https://go.microsoft.com/fwlink/?linkid=2198766
Inner error: {
    "code": "ResponsibleAIPolicyViolation",
    "content_filter_result": {
        "hate": {
            "filtered": false,
            "severity": "safe"
        },
        "self_harm": {
            "filtered": false,
            "severity": "safe"
        },
        "sexual": {
            "filtered": false,
            "severity": "safe"
        },
        "violence": {
            "filtered": true,
            "severity": "medium"
        }
    }
}

```