### PR TITLE
enable azure for audio/whisper

### DIFF
--- a/openai/api_resources/audio.py
+++ b/openai/api_resources/audio.py
@@ -14,8 +14,7 @@ def check_required(*args, method_name, required, **kwargs):
         elif args_count > 0:
             args_count -= 1
             continue
-        else:
-            missing.append(param)
+        missing.append(param)
 
     if missing and "deployment_id" not in kwargs:
         raise TypeError(f"{method_name}() missing {len(missing)} required positional argument(s): {', '.join(missing)}")
@@ -62,9 +61,8 @@ class Audio(APIResource):
     @classmethod
     def transcribe(
         cls,
-        *,
-        deployment_id=None,
-        file=None,
+        model,
+        file,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -78,8 +76,9 @@ class Audio(APIResource):
     @classmethod
     def transcribe(
         cls,
-        model,
-        file,
+        *,
+        deployment_id=None,
+        file=None,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -133,9 +132,8 @@ class Audio(APIResource):
     @classmethod
     def translate(
         cls,
-        *,
-        deployment_id=None,
-        file=None,
+        model,
+        file,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -145,12 +143,14 @@ class Audio(APIResource):
     ):
         ...
 
+
     @overload
     @classmethod
     def translate(
         cls,
-        model,
-        file,
+        *,
+        deployment_id=None,
+        file=None,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -204,10 +204,9 @@ class Audio(APIResource):
     @classmethod
     def transcribe_raw(
         cls,
-        *,
-        deployment_id=None,
-        file=None,
-        filename=None,
+        model,
+        file,
+        filename,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -217,13 +216,15 @@ class Audio(APIResource):
     ):
         ...
 
+
     @overload
     @classmethod
     def transcribe_raw(
         cls,
-        model,
-        file,
-        filename,
+        *,
+        deployment_id=None,
+        file=None,
+        filename=None,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -278,10 +279,9 @@ class Audio(APIResource):
     @classmethod
     def translate_raw(
         cls,
-        *,
-        deployment_id=None,
-        file=None,
-        filename=None,
+        model,
+        file,
+        filename,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -295,9 +295,10 @@ class Audio(APIResource):
     @classmethod
     def translate_raw(
         cls,
-        model,
-        file,
-        filename,
+        *,
+        deployment_id=None,
+        file=None,
+        filename=None,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -352,9 +353,8 @@ class Audio(APIResource):
     @classmethod
     async def atranscribe(
         cls,
-        *,
-        deployment_id=None,
-        file=None,
+        model,
+        file,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -368,8 +368,9 @@ class Audio(APIResource):
     @classmethod
     async def atranscribe(
         cls,
-        model,
-        file,
+        *,
+        deployment_id=None,
+        file=None,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -425,9 +426,8 @@ class Audio(APIResource):
     @classmethod
     async def atranslate(
         cls,
-        *,
-        deployment_id=None,
-        file=None,
+        model,
+        file,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -441,8 +441,9 @@ class Audio(APIResource):
     @classmethod
     async def atranslate(
         cls,
-        model,
-        file,
+        *,
+        deployment_id=None,
+        file=None,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -498,10 +499,9 @@ class Audio(APIResource):
     @classmethod
     async def atranscribe_raw(
         cls,
-        *,
-        deployment_id=None,
-        file=None,
-        filename=None,
+        model,
+        file,
+        filename,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -515,9 +515,10 @@ class Audio(APIResource):
     @classmethod
     async def atranscribe_raw(
         cls,
-        model,
-        file,
-        filename,
+        *,
+        deployment_id=None,
+        file=None,
+        filename=None,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -574,10 +575,9 @@ class Audio(APIResource):
     @classmethod
     async def atranslate_raw(
         cls,
-        *,
-        deployment_id=None,
-        file=None,
-        filename=None,
+        model,
+        file,
+        filename,
         api_key=None,
         api_base=None,
         api_type=None,
@@ -591,9 +591,10 @@ class Audio(APIResource):
     @classmethod
     async def atranslate_raw(
         cls,
-        model,
-        file,
-        filename,
+        *,
+        deployment_id=None,
+        file=None,
+        filename=None,
         api_key=None,
         api_base=None,
         api_type=None,

--- a/openai/tests/test_audio_overloads.py
+++ b/openai/tests/test_audio_overloads.py
@@ -1,0 +1,175 @@
+import openai
+import pytest
+
+
+API_BASE = ""
+AZURE_API_KEY = ""
+OPENAI_API_KEY = ""
+API_VERSION  = ""
+AUDIO_FILE_PATH = ""
+
+
+def test_transcribe():
+
+    # Invalid
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe(
+            "whisper-1",
+            open(AUDIO_FILE_PATH, "rb"),
+            "api_key",
+            "api_base",
+            "api_type",
+            "api_version",
+            "organization",
+            "extra",
+        )
+    assert str(e.value) == "transcribe() takes from 3 to 8 positional arguments but 9 were given"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe()
+    assert str(e.value) == "transcribe() missing 2 required positional argument(s): model, file"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe(
+            "whisper-1"
+        )
+    assert str(e.value) == "transcribe() missing 1 required positional argument(s): file"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe(
+            model="whisper-1"
+        )
+    assert str(e.value) == "transcribe() missing 1 required positional argument(s): file"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe(
+            file=open(AUDIO_FILE_PATH, "rb")
+        )
+    assert str(e.value) == "transcribe() missing 1 required positional argument(s): model"
+
+    # Valid
+    openai.api_key = OPENAI_API_KEY
+    audio = openai.Audio.transcribe(
+        "whisper-1",
+        open(AUDIO_FILE_PATH, "rb")
+    )
+    assert audio
+
+    audio = openai.Audio.transcribe(
+        model="whisper-1",
+        file=open(AUDIO_FILE_PATH, "rb")
+    )
+    assert audio
+
+    openai.api_base = API_BASE
+    openai.api_key = AZURE_API_KEY
+    openai.api_type = "azure"
+    openai.api_version = API_VERSION
+    audio = openai.Audio.transcribe(
+        deployment_id="whisper-1",
+        file=open(AUDIO_FILE_PATH, "rb")
+    )
+    assert audio
+
+
+def test_transcribe_raw():
+
+    # Invalid
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            "whisper-1",
+            open(AUDIO_FILE_PATH, "rb").read(),
+            "filename",
+            "api_key",
+            "api_base",
+            "api_type",
+            "api_version",
+            "organization",
+            "extra",
+        )
+    assert str(e.value) == "transcribe_raw() takes from 4 to 9 positional arguments but 10 were given"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw()
+    assert str(e.value) == "transcribe_raw() missing 3 required positional argument(s): model, file, filename"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            "whisper-1"
+        )
+    assert str(e.value) == "transcribe_raw() missing 2 required positional argument(s): file, filename"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            "whisper-1",
+            open(AUDIO_FILE_PATH, "rb").read()
+        )
+    assert str(e.value) == "transcribe_raw() missing 1 required positional argument(s): filename"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            model="whisper-1"
+        )
+    assert str(e.value) == "transcribe_raw() missing 2 required positional argument(s): file, filename"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            file=open(AUDIO_FILE_PATH, "rb").read()
+        )
+    assert str(e.value) == "transcribe_raw() missing 2 required positional argument(s): model, filename"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            filename="recording.m4a"
+        )
+    assert str(e.value) == "transcribe_raw() missing 2 required positional argument(s): model, file"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            model="whisper-1",
+            file=open(AUDIO_FILE_PATH, "rb").read()
+        )
+    assert str(e.value) == "transcribe_raw() missing 1 required positional argument(s): filename"
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            model="whisper-1",
+            filename="recording.m4a"
+        )
+    assert str(e.value) == "transcribe_raw() missing 1 required positional argument(s): file"
+
+
+    with pytest.raises(TypeError) as e:
+        openai.Audio.transcribe_raw(
+            file=open(AUDIO_FILE_PATH, "rb").read(),
+            filename="recording.m4a"
+        )
+    assert str(e.value) == "transcribe_raw() missing 1 required positional argument(s): model"
+
+
+    # Valid
+    openai.api_key = OPENAI_API_KEY
+    audio = openai.Audio.transcribe_raw(
+        "whisper-1",
+        open(AUDIO_FILE_PATH, "rb").read(),
+        "recording.m4a"
+    )
+    assert audio
+
+    audio = openai.Audio.transcribe_raw(
+        model="whisper-1",
+        file=open(AUDIO_FILE_PATH, "rb").read(),
+        filename="recording.m4a"
+    )
+    assert audio
+
+    openai.api_base = API_BASE
+    openai.api_key = AZURE_API_KEY
+    openai.api_type = "azure"
+    openai.api_version = API_VERSION
+    audio = openai.Audio.transcribe_raw(
+        deployment_id="whisper-1",
+        file=open(AUDIO_FILE_PATH, "rb").read(),
+        filename="recording.m4a"
+    )
+    assert audio


### PR DESCRIPTION
## TODO

Needs more extensive testing

## Description

The Audio/Whisper APIs in the openai library were implemented to work specifically with openai endpoints, e.g. taking a positional param for [model](https://github.com/openai/openai-python/blob/main/openai/api_resources/audio.py#L46). This PR shows how we might change the code so we can use `deployment_id` with Azure, but preserve the positional parameter behavior for `model`, `file`, `filename`, etc.

## Usage

```python
import openai

openai.api_base = "<endpoint>"
openai.api_key = "<api-key>"
openai.api_type = "azure"
openai.api_version = "2023-09-01-preview"

transcribed = openai.Audio.transcribe(
    deployment_id="whisper-1",
    file=open("recording.m4a", "rb")
)

translated = openai.Audio.translate(
    deployment_id="whisper-1",
    file=open("recording.m4a", "rb")
)
```

## Intellisense:

Intellisense shows both options for calling the APIs.

![image](https://github.com/kristapratico/openai-python/assets/31998003/3ebe1a0e-f37b-4986-9b47-8cd48f19349c)
![image](https://github.com/kristapratico/openai-python/assets/31998003/b1843c59-883a-4ac6-b98c-1a793800d608)
