### PR TITLE
azure with options

### DIFF
--- a/src/openai/lib/azure_types.py
+++ b/src/openai/lib/azure_types.py
@@ -37,6 +37,7 @@ __all__ = [
     "OnYourDataVectorizationSourceType",
     "AzureCognitiveSearchQueryType",
     "ElasticsearchQueryType",
+    "AzureChatExtensionConfiguration"
 ]
 
 AzureChatExtensionType = Literal["AzureCognitiveSearch", "AzureMLIndex", "AzureCosmosDB", "Elasticsearch", "Pinecone"]
@@ -52,7 +53,13 @@ OnYourDataAuthenticationType = Literal[
 OnYourDataVectorizationSourceType = Literal["Endpoint", "DeploymentName", "ModelId"]
 AzureCognitiveSearchQueryType = Literal["simple", "semantic", "vector", "vectorSimpleHybrid", "vectorSemanticHybrid"]
 ElasticsearchQueryType = Literal["simple", "vector"]
-
+AzureChatExtensionConfiguration = Union[
+    "AzureCognitiveSearchChatExtensionConfiguration",
+    "AzureCosmosDBChatExtensionConfiguration",
+    "AzureMachineLearningIndexChatExtensionConfiguration",
+    "ElasticsearchChatExtensionConfiguration",
+    "PineconeChatExtensionConfiguration",
+]
 
 class AzureChatEnhancementConfiguration(TypedDict, total=False):
 


### PR DESCRIPTION
Example:

```python
import openai
from openai.types.chat import ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam
from openai.lib.azure_types import (
    AzureCognitiveSearchChatExtensionConfiguration,
    AzureCognitiveSearchChatExtensionParameters,
)

client = openai.AzureOpenAI()

messages = [
    ChatCompletionSystemMessageParam(role="system", content="You are a helpful assistant."),
    ChatCompletionUserMessageParam(role="user", content="How is Azure machine learning different than Azure OpenAI?"),
]

response = client.chat.completions.with_azure_options(
    data_sources=[
        AzureCognitiveSearchChatExtensionConfiguration(
            type="AzureCognitiveSearch",
            parameters=AzureCognitiveSearchChatExtensionParameters(
                index_name="openai-test-index-carbon-wiki",
                endpoint="endpoint",
            ),
        )
    ]
).create(
    model="gpt-4",
    messages=messages,
)
print(response)
```

Intellisense:

![image](https://github.com/kristapratico/openai-python/assets/31998003/15840021-6872-4375-89df-1c16dfe2592e)


Note: You can still use response helpers like `with_raw_response` and `with_streaming_response`, but order matters - they must be called after `with_azure_options(...)`:

```python
response = client.chat.completions.with_azure_options(
    data_sources=[
        AzureCognitiveSearchChatExtensionConfiguration(
            type="AzureCognitiveSearch",
            parameters=AzureCognitiveSearchChatExtensionParameters(
                index_name="openai-test-index-carbon-wiki",
                endpoint="endpoint",
            ),
        )
    ]
).with_raw_response.create(
    model="gpt-4",
    messages=messages,
)
```