### PR TITLE
add auth parameter and AzureAuth

### DIFF
--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -7,7 +7,7 @@ import typing as _t
 from typing_extensions import override
 
 from . import types
-from ._types import NOT_GIVEN, Omit, NoneType, NotGiven, Transport, ProxiesTypes
+from ._types import NOT_GIVEN, Omit, NoneType, NotGiven, TokenAuth, Transport, ProxiesTypes
 from ._utils import file_from_path
 from ._client import Client, OpenAI, Stream, Timeout, Transport, AsyncClient, AsyncOpenAI, AsyncStream, RequestOptions
 from ._models import BaseModel
@@ -124,7 +124,7 @@ from ._base_client import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES
 
 api_key: str | None = None
 
-auth: AzureAuth | None = None
+auth: TokenAuth | None = None
 
 organization: str | None = None
 
@@ -174,11 +174,11 @@ class _ModuleClient(OpenAI):
 
     @property  # type: ignore
     @override
-    def auth(self) -> AzureAuth | None:
+    def auth(self) -> TokenAuth | None:
         return auth
 
     @auth.setter  # type: ignore
-    def auth(self, value: AzureAuth | None) -> None:  # type: ignore
+    def auth(self, value: TokenAuth | None) -> None:  # type: ignore
         global auth
 
         auth = value

--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -87,7 +87,12 @@ if not _t.TYPE_CHECKING:
 
 from .lib import azure as _azure, pydantic_function_tool as pydantic_function_tool
 from .version import VERSION as VERSION
-from .lib.azure import AzureOpenAI as AzureOpenAI, AsyncAzureOpenAI as AsyncAzureOpenAI
+from .lib.azure import (
+    AzureAuth as AzureAuth,
+    AzureOpenAI as AzureOpenAI,
+    AsyncAzureAuth as AsyncAzureAuth,
+    AsyncAzureOpenAI as AsyncAzureOpenAI,
+)
 from .lib._old_api import *
 from .lib.streaming import (
     AssistantEventHandler as AssistantEventHandler,
@@ -118,6 +123,8 @@ import httpx as _httpx
 from ._base_client import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES
 
 api_key: str | None = None
+
+auth: AzureAuth | None = None
 
 organization: str | None = None
 
@@ -164,6 +171,17 @@ class _ModuleClient(OpenAI):
         global api_key
 
         api_key = value
+
+    @property  # type: ignore
+    @override
+    def auth(self) -> AzureAuth | None:
+        return auth
+
+    @auth.setter  # type: ignore
+    def auth(self, value: AzureAuth | None) -> None:  # type: ignore
+        global auth
+
+        auth = value
 
     @property  # type: ignore
     @override
@@ -348,6 +366,7 @@ def _load_client() -> OpenAI:  # type: ignore[reportUnusedFunction]
 
         _client = _ModuleClient(
             api_key=api_key,
+            auth=auth,
             organization=organization,
             project=project,
             webhook_secret=webhook_secret,

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -25,6 +25,7 @@ from ._utils import (
     get_async_library,
 )
 from ._compat import cached_property
+from ._models import FinalRequestOptions
 from ._version import __version__
 from ._streaming import Stream as Stream, AsyncStream as AsyncStream
 from ._exceptions import OpenAIError, APIStatusError
@@ -35,6 +36,7 @@ from ._base_client import (
 )
 
 if TYPE_CHECKING:
+    from .lib.azure import AzureAuth, AsyncAzureAuth
     from .resources import (
         beta,
         chat,
@@ -93,6 +95,7 @@ class OpenAI(SyncAPIClient):
         self,
         *,
         api_key: str | None = None,
+        auth: AzureAuth | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -124,13 +127,16 @@ class OpenAI(SyncAPIClient):
         - `project` from `OPENAI_PROJECT_ID`
         - `webhook_secret` from `OPENAI_WEBHOOK_SECRET`
         """
+        if api_key and auth:
+            raise ValueError("The `api_key` and `auth` arguments are mutually exclusive")
         if api_key is None:
             api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key is None:
+        if api_key is None and auth is None:
             raise OpenAIError(
-                "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+                "The api_key or auth client option must be set either by passing api_key or auth to the client or by setting the OPENAI_API_KEY environment variable"
             )
-        self.api_key = api_key
+        self.auth = auth
+        self.api_key = api_key or ""
 
         if organization is None:
             organization = os.environ.get("OPENAI_ORG_ID")
@@ -163,6 +169,7 @@ class OpenAI(SyncAPIClient):
         )
 
         self._default_stream_cls = Stream
+        self._auth_headers: dict[str, str] = {}
 
     @cached_property
     def completions(self) -> Completions:
@@ -279,14 +286,25 @@ class OpenAI(SyncAPIClient):
     def qs(self) -> Querystring:
         return Querystring(array_format="brackets")
 
+    def refresh_auth_headers(self) -> None:
+        secret = self.auth.get_token() if self.auth else self.api_key
+        if not secret:
+            # if secret is an empty string, encoding the header will fail
+            # so we set it to an empty dict
+            # this is to avoid sending an invalid Authorization header
+            self._auth_headers = {}
+        else:
+            self._auth_headers = {"Authorization": f"Bearer {secret}"}
+
+    @override
+    def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        self.refresh_auth_headers()
+        return super()._prepare_options(options)
+
     @property
     @override
     def auth_headers(self) -> dict[str, str]:
-        api_key = self.api_key
-        if not api_key:
-            # if the api key is an empty string, encoding the header will fail
-            return {}
-        return {"Authorization": f"Bearer {api_key}"}
+        return self._auth_headers
 
     @property
     @override
@@ -303,6 +321,7 @@ class OpenAI(SyncAPIClient):
         self,
         *,
         api_key: str | None = None,
+        auth: AzureAuth | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -337,6 +356,10 @@ class OpenAI(SyncAPIClient):
             params = {**params, **default_query}
         elif set_default_query is not None:
             params = set_default_query
+
+        auth = auth or self.auth
+        if auth is not None:
+            _extra_kwargs = {**_extra_kwargs, "auth": auth}
 
         http_client = http_client or self._client
         return self.__class__(
@@ -412,6 +435,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self,
         *,
         api_key: str | None = None,
+        auth: AsyncAzureAuth | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -443,13 +467,16 @@ class AsyncOpenAI(AsyncAPIClient):
         - `project` from `OPENAI_PROJECT_ID`
         - `webhook_secret` from `OPENAI_WEBHOOK_SECRET`
         """
+        if api_key and auth:
+            raise ValueError("The `api_key` and `auth` arguments are mutually exclusive")
         if api_key is None:
             api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key is None:
+        if api_key is None and auth is None:
             raise OpenAIError(
-                "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+                "The api_key or auth client option must be set either by passing api_key or auth to the client or by setting the OPENAI_API_KEY environment variable"
             )
-        self.api_key = api_key
+        self.auth = auth
+        self.api_key = api_key or ""
 
         if organization is None:
             organization = os.environ.get("OPENAI_ORG_ID")
@@ -482,6 +509,7 @@ class AsyncOpenAI(AsyncAPIClient):
         )
 
         self._default_stream_cls = AsyncStream
+        self._auth_headers: dict[str, str] = {}
 
     @cached_property
     def completions(self) -> AsyncCompletions:
@@ -598,14 +626,28 @@ class AsyncOpenAI(AsyncAPIClient):
     def qs(self) -> Querystring:
         return Querystring(array_format="brackets")
 
+    async def refresh_auth_headers(self) -> None:
+        if self.auth:
+            secret = await self.auth.get_token()
+        else:
+            secret = self.api_key
+        if not secret:
+            # if the secret is an empty string, encoding the header will fail
+            # so we set it to an empty dict
+            # this is to avoid sending an invalid Authorization header
+            self._auth_headers = {}
+        else:
+            self._auth_headers = {"Authorization": f"Bearer {secret}"}
+
+    @override
+    async def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        await self.refresh_auth_headers()
+        return await super()._prepare_options(options)
+
     @property
     @override
     def auth_headers(self) -> dict[str, str]:
-        api_key = self.api_key
-        if not api_key:
-            # if the api key is an empty string, encoding the header will fail
-            return {}
-        return {"Authorization": f"Bearer {api_key}"}
+        return self._auth_headers
 
     @property
     @override
@@ -622,6 +664,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self,
         *,
         api_key: str | None = None,
+        auth: AsyncAzureAuth | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -656,6 +699,10 @@ class AsyncOpenAI(AsyncAPIClient):
             params = {**params, **default_query}
         elif set_default_query is not None:
             params = set_default_query
+
+        auth = auth or self.auth
+        if auth is not None:
+            _extra_kwargs = {**_extra_kwargs, "auth": auth}
 
         http_client = http_client or self._client
         return self.__class__(

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -15,8 +15,10 @@ from ._types import (
     Omit,
     Timeout,
     NotGiven,
+    TokenAuth,
     Transport,
     ProxiesTypes,
+    AsyncTokenAuth,
     RequestOptions,
 )
 from ._utils import (
@@ -36,7 +38,6 @@ from ._base_client import (
 )
 
 if TYPE_CHECKING:
-    from .lib.azure import AzureAuth, AsyncAzureAuth
     from .resources import (
         beta,
         chat,
@@ -95,7 +96,7 @@ class OpenAI(SyncAPIClient):
         self,
         *,
         api_key: str | None = None,
-        auth: AzureAuth | None = None,
+        auth: TokenAuth | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -321,7 +322,7 @@ class OpenAI(SyncAPIClient):
         self,
         *,
         api_key: str | None = None,
-        auth: AzureAuth | None = None,
+        auth: TokenAuth | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -435,7 +436,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self,
         *,
         api_key: str | None = None,
-        auth: AsyncAzureAuth | None = None,
+        auth: AsyncTokenAuth | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -664,7 +665,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self,
         *,
         api_key: str | None = None,
-        auth: AsyncAzureAuth | None = None,
+        auth: AsyncTokenAuth | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,

--- a/src/openai/_types.py
+++ b/src/openai/_types.py
@@ -219,3 +219,11 @@ class _GenericAlias(Protocol):
 class HttpxSendArgs(TypedDict, total=False):
     auth: httpx.Auth
     follow_redirects: bool
+
+
+class TokenAuth(Protocol):
+    def get_token(self) -> str: ...
+
+
+class AsyncTokenAuth(Protocol):
+    async def get_token(self) -> str: ...

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -74,6 +74,18 @@ class AzureAuth:
             raise ValueError("The `token_provider` and `credential` arguments are mutually exclusive.")
         if token_provider is None and credential is None:
             raise ValueError("One of `token_provider` or `credential` must be provided to AzureAuth.")
+        if isinstance(scopes, str):  # type: ignore[unreachable]
+            raise TypeError("`scopes` must be a list of strings, not a single string.")
+
+        if credential is not None:
+            try:
+                from azure.identity import get_bearer_token_provider
+            except ImportError as err:
+                raise ImportError(
+                    "azure-identity library is not installed. Please install it to use AzureAuth."
+                ) from err
+            token_provider = get_bearer_token_provider(credential, *scopes)
+
         self.token_provider = token_provider
         self.credential = credential
         self.scopes = scopes
@@ -81,17 +93,6 @@ class AzureAuth:
     def get_token(self) -> str:
         if self.token_provider is not None:
             token = self.token_provider()
-            return token
-
-        if self.credential is not None:
-            try:
-                from azure.identity import get_bearer_token_provider
-            except ImportError as err:
-                raise ImportError(
-                    "azure-identity library is not installed. Please install it to use AzureAuth."
-                ) from err
-            token_provider = get_bearer_token_provider(self.credential, *self.scopes)
-            token = token_provider()
             return token
 
         raise ValueError("Unexpected values provided to AzureAuth. Unable to get token.")
@@ -120,6 +121,18 @@ class AsyncAzureAuth:
             raise ValueError("The `token_provider` and `credential` arguments are mutually exclusive.")
         if token_provider is None and credential is None:
             raise ValueError("One of `token_provider` or `credential` must be provided to AsyncAzureAuth.")
+        if isinstance(scopes, str):  # type: ignore[unreachable]
+            raise TypeError("`scopes` must be a list of strings, not a single string.")
+
+        if credential is not None:
+            try:
+                from azure.identity.aio import get_bearer_token_provider
+            except ImportError as err:
+                raise ImportError(
+                    "azure-identity library is not installed. Please install it to use AsyncAzureAuth."
+                ) from err
+            token_provider = get_bearer_token_provider(credential, *scopes)
+
         self.token_provider = token_provider
         self.credential = credential
         self.scopes = scopes
@@ -127,17 +140,6 @@ class AsyncAzureAuth:
     async def get_token(self) -> str:
         if self.token_provider is not None:
             token = await self.token_provider()
-            return token
-
-        if self.credential is not None:
-            try:
-                from azure.identity.aio import get_bearer_token_provider
-            except ImportError as err:
-                raise ImportError(
-                    "azure-identity library is not installed. Please install it to use AsyncAzureAuth."
-                ) from err
-            token_provider = get_bearer_token_provider(self.credential, *self.scopes)
-            token = await token_provider()
             return token
 
         raise ValueError("Unexpected values provided to AsyncAzureAuth. Unable to get token.")

--- a/src/openai/resources/beta/realtime/realtime.py
+++ b/src/openai/resources/beta/realtime/realtime.py
@@ -358,6 +358,7 @@ class AsyncRealtimeConnectionManager:
             raise OpenAIError("You need to install `openai[realtime]` to use this method") from exc
 
         extra_query = self.__extra_query
+        await self.__client.refresh_auth_headers()
         auth_headers = self.__client.auth_headers
         if is_async_azure_client(self.__client):
             url, auth_headers = await self.__client._configure_realtime(self.__model, extra_query)
@@ -540,6 +541,7 @@ class RealtimeConnectionManager:
             raise OpenAIError("You need to install `openai[realtime]` to use this method") from exc
 
         extra_query = self.__extra_query
+        self.__client.refresh_auth_headers()
         auth_headers = self.__client.auth_headers
         if is_azure_client(self.__client):
             url, auth_headers = self.__client._configure_realtime(self.__model, extra_query)

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -821,7 +821,6 @@ class TestAzureAuth:
     def test_init_with_credential(self) -> None:
         auth = AzureAuth(credential=mock_credential)
         assert auth.credential is mock_credential
-        assert auth.token_provider is None
         assert auth.scopes == ["https://cognitiveservices.azure.com/.default"]
 
     def test_init_with_custom_scopes(self) -> None:
@@ -852,13 +851,12 @@ class TestAzureAuth:
         assert token == expected_token
 
     def test_get_token_with_credential(self) -> None:
-        auth = AzureAuth(credential=mock_credential)
-
         with patch("azure.identity.get_bearer_token_provider") as mock_provider:
             mock_token_provider = MagicMock()
             mock_token_provider.return_value = "azure-token-789"
             mock_provider.return_value = mock_token_provider
 
+            auth = AzureAuth(credential=mock_credential)
             token = auth.get_token()
 
             assert token == "azure-token-789"
@@ -881,7 +879,6 @@ class TestAsyncAzureAuth:
     def test_init_with_credential(self) -> None:
         auth = AsyncAzureAuth(credential=mock_credential)
         assert auth.credential is mock_credential
-        assert auth.token_provider is None
         assert auth.scopes == ["https://cognitiveservices.azure.com/.default"]
 
     def test_init_with_custom_scopes(self) -> None:
@@ -914,13 +911,12 @@ class TestAsyncAzureAuth:
 
     @pytest.mark.asyncio
     async def test_get_token_with_credential(self) -> None:
-        auth = AsyncAzureAuth(credential=mock_credential)
-
         with patch("azure.identity.aio.get_bearer_token_provider") as mock_provider:
             mock_token_provider = AsyncMock()
             mock_token_provider.return_value = "async-azure-token-789"
             mock_provider.return_value = mock_token_provider
 
+            auth = AsyncAzureAuth(credential=mock_credential)
             token = await auth.get_token()
 
             assert token == "async-azure-token-789"

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Union, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 from typing_extensions import Literal, Protocol
 
 import httpx
@@ -10,10 +11,11 @@ from respx import MockRouter
 
 from openai._utils import SensitiveHeadersFilter, is_dict
 from openai._models import FinalRequestOptions
-from openai.lib.azure import AzureOpenAI, AsyncAzureOpenAI
+from openai.lib.azure import AzureAuth, AzureOpenAI, AsyncAzureAuth, AsyncAzureOpenAI
 
 Client = Union[AzureOpenAI, AsyncAzureOpenAI]
 
+mock_credential = MagicMock()
 
 sync_client = AzureOpenAI(
     api_version="2023-07-01",
@@ -802,3 +804,125 @@ def test_client_sets_base_url(client: Client) -> None:
         )
     )
     assert req.url == "https://example-resource.azure.openai.com/openai/models?api-version=2024-02-01"
+
+
+class TestAzureAuth:
+    """Test cases for the AzureAuth class."""
+
+    def test_init_with_token_provider(self) -> None:
+        def token_provider() -> str:
+            return "test-token-123"
+
+        auth = AzureAuth(token_provider=token_provider)
+        assert auth.token_provider is token_provider
+        assert auth.credential is None
+        assert auth.scopes == ["https://cognitiveservices.azure.com/.default"]
+
+    def test_init_with_credential(self) -> None:
+        auth = AzureAuth(credential=mock_credential)
+        assert auth.credential is mock_credential
+        assert auth.token_provider is None
+        assert auth.scopes == ["https://cognitiveservices.azure.com/.default"]
+
+    def test_init_with_custom_scopes(self) -> None:
+        custom_scopes = ["https://custom.scope/.default"]
+
+        auth = AzureAuth(credential=mock_credential, scopes=custom_scopes)
+        assert auth.scopes == custom_scopes
+
+    def test_init_mutually_exclusive_raises_error(self) -> None:
+        def token_provider() -> str:
+            return "test-token-123"
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AzureAuth(token_provider=token_provider, credential=mock_credential)  # type: ignore[misc]
+
+    def test_init_with_no_params_raises_error(self) -> None:
+        with pytest.raises(ValueError, match="One of `token_provider` or `credential` must be provided"):
+            AzureAuth()  # type: ignore[misc]
+
+    def test_get_token_with_token_provider(self) -> None:
+        expected_token = "test-token-456"
+
+        def token_provider() -> str:
+            return expected_token
+
+        auth = AzureAuth(token_provider=token_provider)
+        token = auth.get_token()
+        assert token == expected_token
+
+    def test_get_token_with_credential(self) -> None:
+        auth = AzureAuth(credential=mock_credential)
+
+        with patch("azure.identity.get_bearer_token_provider") as mock_provider:
+            mock_token_provider = MagicMock()
+            mock_token_provider.return_value = "azure-token-789"
+            mock_provider.return_value = mock_token_provider
+
+            token = auth.get_token()
+
+            assert token == "azure-token-789"
+            mock_provider.assert_called_once_with(mock_credential, *auth.scopes)
+            mock_token_provider.assert_called_once()
+
+
+class TestAsyncAzureAuth:
+    """Test cases for the AsyncAzureAuth class."""
+
+    def test_init_with_token_provider(self) -> None:
+        async def async_token_provider() -> str:
+            return "async-test-token-123"
+
+        auth = AsyncAzureAuth(token_provider=async_token_provider)
+        assert auth.token_provider is async_token_provider
+        assert auth.credential is None
+        assert auth.scopes == ["https://cognitiveservices.azure.com/.default"]
+
+    def test_init_with_credential(self) -> None:
+        auth = AsyncAzureAuth(credential=mock_credential)
+        assert auth.credential is mock_credential
+        assert auth.token_provider is None
+        assert auth.scopes == ["https://cognitiveservices.azure.com/.default"]
+
+    def test_init_with_custom_scopes(self) -> None:
+        custom_scopes = ["https://custom.scope/.default"]
+
+        auth = AsyncAzureAuth(credential=mock_credential, scopes=custom_scopes)
+        assert auth.scopes == custom_scopes
+
+    def test_init_mutually_exclusive_raises_error(self) -> None:
+        async def async_token_provider() -> str:
+            return "async-test-token-123"
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AsyncAzureAuth(token_provider=async_token_provider, credential=mock_credential)  # type: ignore[misc]
+
+    def test_init_with_no_params_raises_error(self) -> None:
+        with pytest.raises(ValueError, match="One of `token_provider` or `credential` must be provided"):
+            AsyncAzureAuth()  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_get_token_with_token_provider(self) -> None:
+        expected_token = "async-test-token-456"
+
+        async def async_token_provider() -> str:
+            return expected_token
+
+        auth = AsyncAzureAuth(token_provider=async_token_provider)
+        token = await auth.get_token()
+        assert token == expected_token
+
+    @pytest.mark.asyncio
+    async def test_get_token_with_credential(self) -> None:
+        auth = AsyncAzureAuth(credential=mock_credential)
+
+        with patch("azure.identity.aio.get_bearer_token_provider") as mock_provider:
+            mock_token_provider = AsyncMock()
+            mock_token_provider.return_value = "async-azure-token-789"
+            mock_provider.return_value = mock_token_provider
+
+            token = await auth.get_token()
+
+            assert token == "async-azure-token-789"
+            mock_provider.assert_called_once_with(mock_credential, *auth.scopes)
+            mock_token_provider.assert_awaited_once()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ import asyncio
 import inspect
 import subprocess
 import tracemalloc
-from typing import Any, Union, cast
+from typing import Any, Union, Protocol, cast
 from textwrap import dedent
 from unittest import mock
 from typing_extensions import Literal
@@ -21,7 +21,7 @@ import pytest
 from respx import MockRouter
 from pydantic import ValidationError
 
-from openai import OpenAI, AsyncOpenAI, APIResponseValidationError
+from openai import OpenAI, AzureAuth, AsyncOpenAI, AsyncAzureAuth, APIResponseValidationError
 from openai._types import Omit
 from openai._models import BaseModel, FinalRequestOptions
 from openai._streaming import Stream, AsyncStream
@@ -39,6 +39,10 @@ from .utils import update_env
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 api_key = "My API Key"
+
+
+class MockRequestCall(Protocol):
+    request: httpx.Request
 
 
 def _get_params(client: BaseClient[Any, Any]) -> dict[str, str]:
@@ -337,7 +341,9 @@ class TestOpenAI:
 
     def test_validate_headers(self) -> None:
         client = OpenAI(base_url=base_url, api_key=api_key, _strict_response_validation=True)
-        request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
+        options = client._prepare_options(FinalRequestOptions(method="get", url="/foo"))
+        request = client._build_request(options)
+
         assert request.headers.get("Authorization") == f"Bearer {api_key}"
 
         with pytest.raises(OpenAIError):
@@ -939,6 +945,63 @@ class TestOpenAI:
         assert exc_info.value.response.status_code == 302
         assert exc_info.value.response.headers["Location"] == f"{base_url}/redirected"
 
+    def test_refresh_auth_headers_token(self) -> None:
+        client = OpenAI(base_url=base_url, auth=AzureAuth(token_provider=lambda: "test_bearer_token"))
+        client.refresh_auth_headers()
+        assert client.auth_headers.get("Authorization") == "Bearer test_bearer_token"
+
+    def test_refresh_auth_headers_key(self) -> None:
+        client = OpenAI(base_url=base_url, api_key="test_api_key")
+        client.refresh_auth_headers()
+        assert client.auth_headers.get("Authorization") == "Bearer test_api_key"
+
+    @pytest.mark.respx()
+    def test_auth_provider_refresh(self, respx_mock: MockRouter) -> None:
+        respx_mock.post(base_url + "/chat/completions").mock(
+            side_effect=[
+                httpx.Response(500, json={"error": "server error"}),
+                httpx.Response(200, json={"foo": "bar"}),
+            ]
+        )
+
+        counter = 0
+
+        def token_provider() -> str:
+            nonlocal counter
+
+            counter += 1
+
+            if counter == 1:
+                return "first"
+
+            return "second"
+
+        client = OpenAI(base_url=base_url, auth=AzureAuth(token_provider=token_provider))
+        client.chat.completions.create(messages=[], model="gpt-4")
+
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 2
+
+        assert calls[0].request.headers.get("Authorization") == "Bearer first"
+        assert calls[1].request.headers.get("Authorization") == "Bearer second"
+
+    def test_auth_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            OpenAI(base_url=base_url, api_key=api_key, auth=AzureAuth(token_provider=lambda: "test_bearer_token"))
+        assert str(exc_info.value) == "The `api_key` and `auth` arguments are mutually exclusive"
+
+    def test_copy_auth(self) -> None:
+        client = OpenAI(base_url=base_url, auth=AzureAuth(token_provider=lambda: "test_bearer_token_1")).copy(
+            auth=AzureAuth(token_provider=lambda: "test_bearer_token_2")
+        )
+        client.refresh_auth_headers()
+        assert client.auth_headers == {"Authorization": "Bearer test_bearer_token_2"}
+
+    def test_copy_auth_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            OpenAI(base_url=base_url, api_key=api_key).copy(auth=AzureAuth(token_provider=lambda: "test_bearer_token"))
+        assert str(exc_info.value) == "The `api_key` and `auth` arguments are mutually exclusive"
+
 
 class TestAsyncOpenAI:
     client = AsyncOpenAI(base_url=base_url, api_key=api_key, _strict_response_validation=True)
@@ -1220,9 +1283,10 @@ class TestAsyncOpenAI:
         assert request.headers.get("x-foo") == "stainless"
         assert request.headers.get("x-stainless-lang") == "my-overriding-header"
 
-    def test_validate_headers(self) -> None:
+    async def test_validate_headers(self) -> None:
         client = AsyncOpenAI(base_url=base_url, api_key=api_key, _strict_response_validation=True)
-        request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
+        options = await client._prepare_options(FinalRequestOptions(method="get", url="/foo"))
+        request = client._build_request(options)
         assert request.headers.get("Authorization") == f"Bearer {api_key}"
 
         with pytest.raises(OpenAIError):
@@ -1887,3 +1951,79 @@ class TestAsyncOpenAI:
 
         assert exc_info.value.response.status_code == 302
         assert exc_info.value.response.headers["Location"] == f"{base_url}/redirected"
+
+    @pytest.mark.asyncio
+    async def test_refresh_auth_headers_token_async(self) -> None:
+        async def token_provider() -> str:
+            return "test_bearer_token"
+
+        client = AsyncOpenAI(base_url=base_url, auth=AsyncAzureAuth(token_provider=token_provider))
+        await client.refresh_auth_headers()
+        assert client.auth_headers.get("Authorization") == "Bearer test_bearer_token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_auth_headers_key_async(self) -> None:
+        client = AsyncOpenAI(base_url=base_url, api_key="test_api_key")
+        await client.refresh_auth_headers()
+        assert client.auth_headers.get("Authorization") == "Bearer test_api_key"
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx()
+    async def test_bearer_token_refresh_async(self, respx_mock: MockRouter) -> None:
+        respx_mock.post(base_url + "/chat/completions").mock(
+            side_effect=[
+                httpx.Response(500, json={"error": "server error"}),
+                httpx.Response(200, json={"foo": "bar"}),
+            ]
+        )
+
+        counter = 0
+
+        async def token_provider() -> str:
+            nonlocal counter
+
+            counter += 1
+
+            if counter == 1:
+                return "first"
+
+            return "second"
+
+        client = AsyncOpenAI(base_url=base_url, auth=AsyncAzureAuth(token_provider=token_provider))
+        await client.chat.completions.create(messages=[], model="gpt-4")
+
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 2
+
+        assert calls[0].request.headers.get("Authorization") == "Bearer first"
+        assert calls[1].request.headers.get("Authorization") == "Bearer second"
+
+    def test_auth_mutually_exclusive_async(self) -> None:
+        async def token_provider() -> str:
+            return "test_bearer_token"
+
+        with pytest.raises(ValueError) as exc_info:
+            AsyncOpenAI(base_url=base_url, api_key=api_key, auth=AsyncAzureAuth(token_provider=token_provider))
+        assert str(exc_info.value) == "The `api_key` and `auth` arguments are mutually exclusive"
+
+    @pytest.mark.asyncio
+    async def test_copy_auth(self) -> None:
+        async def token_provider_1() -> str:
+            return "test_bearer_token_1"
+
+        async def token_provider_2() -> str:
+            return "test_bearer_token_2"
+
+        client = AsyncOpenAI(base_url=base_url, auth=AsyncAzureAuth(token_provider=token_provider_1)).copy(
+            auth=AsyncAzureAuth(token_provider=token_provider_2)
+        )
+        await client.refresh_auth_headers()
+        assert client.auth_headers == {"Authorization": "Bearer test_bearer_token_2"}
+
+    def test_copy_auth_mutually_exclusive_async(self) -> None:
+        async def token_provider() -> str:
+            return "test_bearer_token"
+
+        with pytest.raises(ValueError) as exc_info:
+            AsyncOpenAI(base_url=base_url, api_key=api_key).copy(auth=AsyncAzureAuth(token_provider=token_provider))
+        assert str(exc_info.value) == "The `api_key` and `auth` arguments are mutually exclusive"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -956,7 +956,7 @@ class TestOpenAI:
         assert client.auth_headers.get("Authorization") == "Bearer test_api_key"
 
     @pytest.mark.respx()
-    def test_auth_provider_refresh(self, respx_mock: MockRouter) -> None:
+    def test_bearer_token_refresh(self, respx_mock: MockRouter) -> None:
         respx_mock.post(base_url + "/chat/completions").mock(
             side_effect=[
                 httpx.Response(500, json={"error": "server error"}),

--- a/tests/test_module_client.py
+++ b/tests/test_module_client.py
@@ -9,12 +9,13 @@ import pytest
 from httpx import URL
 
 import openai
-from openai import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES
+from openai import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES, AzureAuth
 
 
 def reset_state() -> None:
     openai._reset_client()
     openai.api_key = None or "My API Key"
+    openai.auth = None
     openai.organization = None
     openai.project = None
     openai.webhook_secret = None
@@ -97,6 +98,17 @@ def test_http_client_option() -> None:
     assert openai.completions._client._client is new_client
 
 
+def test_auth_provider_option() -> None:
+    assert openai.auth is None
+    assert openai.completions._client.auth is None
+
+    openai.auth = AzureAuth(token_provider=lambda: "foo")
+
+    assert openai.auth.get_token() == "foo"
+    assert openai.completions._client.auth
+    assert openai.completions._client.auth.get_token() == "foo"
+
+
 import contextlib
 from typing import Iterator
 
@@ -121,6 +133,27 @@ def test_only_api_key_results_in_openai_api() -> None:
         openai.api_key = "example API key"
 
         assert type(openai.completions._client).__name__ == "_ModuleClient"
+
+
+def test_only_auth_provider_in_openai_api() -> None:
+    with fresh_env():
+        openai.api_type = None
+        openai.api_key = None
+        openai.auth = AzureAuth(token_provider=lambda: "foo")
+
+        assert type(openai.completions._client).__name__ == "_ModuleClient"
+
+
+def test_both_api_key_and_auth_provider_in_openai_api() -> None:
+    with fresh_env():
+        openai.api_key = "example API key"
+        openai.auth = AzureAuth(token_provider=lambda: "foo")
+
+        with pytest.raises(
+            ValueError,
+            match=r"The `api_key` and `auth` arguments are mutually exclusive",
+        ):
+            openai.completions._client  # noqa: B018
 
 
 def test_azure_api_key_env_without_api_version() -> None:

--- a/tests/test_module_client.py
+++ b/tests/test_module_client.py
@@ -98,7 +98,7 @@ def test_http_client_option() -> None:
     assert openai.completions._client._client is new_client
 
 
-def test_auth_provider_option() -> None:
+def test_auth_option() -> None:
     assert openai.auth is None
     assert openai.completions._client.auth is None
 
@@ -135,7 +135,7 @@ def test_only_api_key_results_in_openai_api() -> None:
         assert type(openai.completions._client).__name__ == "_ModuleClient"
 
 
-def test_only_auth_provider_in_openai_api() -> None:
+def test_only_auth_in_openai_api() -> None:
     with fresh_env():
         openai.api_type = None
         openai.api_key = None
@@ -144,7 +144,7 @@ def test_only_auth_provider_in_openai_api() -> None:
         assert type(openai.completions._client).__name__ == "_ModuleClient"
 
 
-def test_both_api_key_and_auth_provider_in_openai_api() -> None:
+def test_both_api_key_and_auth_in_openai_api() -> None:
     with fresh_env():
         openai.api_key = "example API key"
         openai.auth = AzureAuth(token_provider=lambda: "foo")


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Example usages:

```python
from openai import OpenAI, AzureAuth
from azure.identity import get_bearer_token_provider, DefaultAzureCredential

token_provider = get_bearer_token_provider(DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default")

client = OpenAI(
    base_url="https://resource.openai.azure.com/openai/v1",
    auth=AzureAuth(token_provider=token_provider),
    default_query={"api-version": "preview"}
)
```

```python
from openai import OpenAI, AzureAuth
from azure.identity import DefaultAzureCredential

client = OpenAI(
    base_url="https://resource.openai.azure.com/openai/v1",
    auth=AzureAuth(credential=DefaultAzureCredential()),
    default_query={"api-version": "preview"}
)
```

## Additional context & links
